### PR TITLE
修复issue#34中提到的bug

### DIFF
--- a/src/com/ms509/ui/menu/FileManagerPopMenu.java
+++ b/src/com/ms509/ui/menu/FileManagerPopMenu.java
@@ -156,8 +156,11 @@ public class FileManagerPopMenu extends JPopupMenu {
 						final String abpath = Common.autoPath(path.getText())
 								+ name + Safe.SYSTEMSP;
 						filemanagerpanel.showRight(abpath, list);
-						DefaultMutableTreeNode tn = TreeMethod.searchNode(
-								filemanagerpanel.getRoot(), name);
+						
+						//DefaultMutableTreeNode tn = TreeMethod.searchNode(
+								//filemanagerpanel.getRoot(), name);
+						DefaultMutableTreeNode tn = TreeMethod.searchNodeByAbsolutePath(
+								filemanagerpanel.getRoot(), abpath);
 						if (tn != null) {
 							TreePath tp = new TreePath(tn.getPath());
 							DefaultTreeSelectionModel dsmodel = new DefaultTreeSelectionModel();

--- a/src/com/ms509/ui/panel/FileManagerPanel.java
+++ b/src/com/ms509/ui/panel/FileManagerPanel.java
@@ -207,10 +207,6 @@ public class FileManagerPanel extends JPanel {
 		Runnable run = new Runnable() {
 			public void run() {
 				arrtmp = fm.doAction("readindex");
-				//System.out.println("arrtmp is:");
-				//System.out.println(arrtmp);
-				// System.out.println(arrtmp);
-
 				if (arrtmp.indexOf("HTTP/1.") > -1 || arrtmp.indexOf("/") < 0
 						&& arrtmp.indexOf("\\") < 0) {
 					SwingUtilities.invokeLater(new Runnable() {

--- a/src/com/ms509/ui/panel/FileManagerPanel.java
+++ b/src/com/ms509/ui/panel/FileManagerPanel.java
@@ -207,6 +207,8 @@ public class FileManagerPanel extends JPanel {
 		Runnable run = new Runnable() {
 			public void run() {
 				arrtmp = fm.doAction("readindex");
+				//System.out.println("arrtmp is:");
+				//System.out.println(arrtmp);
 				// System.out.println(arrtmp);
 
 				if (arrtmp.indexOf("HTTP/1.") > -1 || arrtmp.indexOf("/") < 0

--- a/src/com/ms509/util/Common.java
+++ b/src/com/ms509/util/Common.java
@@ -22,8 +22,6 @@ public class Common {
 
 	public static String purData(String data) {
 		String datas = data;
-		//System.out.println("datas is:");
-		//System.out.println(datas);
 		String regex = Common.purRegex(Safe.SPL) + "(.*)"
 				+ Common.purRegex(Safe.SPR);
 		Matcher m = Pattern.compile(regex, Pattern.DOTALL).matcher(data);

--- a/src/com/ms509/util/Common.java
+++ b/src/com/ms509/util/Common.java
@@ -22,6 +22,8 @@ public class Common {
 
 	public static String purData(String data) {
 		String datas = data;
+		//System.out.println("datas is:");
+		//System.out.println(datas);
 		String regex = Common.purRegex(Safe.SPL) + "(.*)"
 				+ Common.purRegex(Safe.SPR);
 		Matcher m = Pattern.compile(regex, Pattern.DOTALL).matcher(data);

--- a/src/com/ms509/util/FileManager.java
+++ b/src/com/ms509/util/FileManager.java
@@ -429,8 +429,7 @@ public class FileManager {
 				}
 			}
 			String[] left = al.toArray(new String[] {});
-			return left;
-			
+			return left;			
 		} catch (Exception e) {
 			return filedicts = new String[]{};
 		}

--- a/src/com/ms509/util/FileManager.java
+++ b/src/com/ms509/util/FileManager.java
@@ -430,6 +430,7 @@ public class FileManager {
 			}
 			String[] left = al.toArray(new String[] {});
 			return left;
+			
 		} catch (Exception e) {
 			return filedicts = new String[]{};
 		}

--- a/src/com/ms509/util/TreeMethod.java
+++ b/src/com/ms509/util/TreeMethod.java
@@ -94,10 +94,43 @@ public class TreeMethod {
 		Enumeration e = root.breadthFirstEnumeration();
 		while (e.hasMoreElements()) {
 			node = (DefaultMutableTreeNode) e.nextElement();
+			System.out.println("the current visiting node is:");
+			//System.out.println(node.getUserObject());
 			if (name.equalsIgnoreCase(node.getUserObject().toString())) {
 				return node;
 			}
 		}
 		return null;
 	}
+	
+	public static DefaultMutableTreeNode searchNodeByAbsolutePath(
+			DefaultMutableTreeNode root, String abpath) {
+		DefaultMutableTreeNode node = null;
+		Enumeration e = root.breadthFirstEnumeration();
+		while (e.hasMoreElements()) {
+			node = (DefaultMutableTreeNode) e.nextElement();
+			//System.out.println(node.getUserObject());
+			Object[] treepath = node.getUserObjectPath();
+			String treepathString = "";
+			for(int i=0;i<treepath.length;i++)
+			{
+				if(i==0)
+				{
+					treepathString=treepath[i].toString();
+				}
+				else
+				{
+					treepathString=treepathString+treepath[i].toString()+Safe.SYSTEMSP;
+				}
+			}
+			if (treepathString.startsWith(abpath)) {
+				return node;
+			}
+			if (abpath.equalsIgnoreCase(node.getUserObject().toString())) {
+				return node;
+			}
+		}
+		return null;
+	}
+	
 }

--- a/src/com/ms509/util/TreeMethod.java
+++ b/src/com/ms509/util/TreeMethod.java
@@ -94,8 +94,6 @@ public class TreeMethod {
 		Enumeration e = root.breadthFirstEnumeration();
 		while (e.hasMoreElements()) {
 			node = (DefaultMutableTreeNode) e.nextElement();
-			System.out.println("the current visiting node is:");
-			//System.out.println(node.getUserObject());
 			if (name.equalsIgnoreCase(node.getUserObject().toString())) {
 				return node;
 			}


### PR DESCRIPTION
修复[issue#34](https://github.com/Chora10/Cknife/issues/34)中的bug
问题的根源在于TreeMethod.java中的searchNode()有可能把上级子树中同名文件当成我们希望打开的文件。
bug复现:PHP一句话webshell位于/var/www/dvwa/hackable/uploads
我们有一个user文件夹(/var/www/dvwa/hackable/user/user/)，我们想从其父目录(/var/www/dvwa/hackable/user/)中，通过右侧窗口通过右弹出键菜单栏-打开。
于此同时，存在另一个目录(/var/www/dvwa/users/).

在(/var/www/dvwa/hackable/user/)中，通过右侧窗口通过右键弹出菜单栏-打开进入(/var/www/dvwa/hackable/user/user/)时，会发现右侧区域正确进入了(/var/www/dvwa/hackable/user/user/)。左侧的目录树路径却进入了(/var/www/dvwa/hackable/user/).

原因在于，searchNode(root, name)方法通过广度优先搜索寻找名字为name的节点（此处的name不包含路径，因此在上述例子中，name为user)。该方法一旦找到name的同名节点就直接return，因此，在上例中(/var/www/dvwa/hackable/user/)节点被返回给左侧,然而我们希望返回(/var/www/dvwa/hackable/user/user/)...

目录结构见截图:
![2312](https://user-images.githubusercontent.com/16850039/35924342-be8be3ce-0c5d-11e8-943d-47bef5d4c18c.PNG)


所以，我在TreeMethod.java中新增了一个searchNodeByAbsolutePath(root,abpath)方法，并在FileManagerPopMenu.java中用它替换掉searchNode(root,name)方法。

新的方法根据节点相对于根节点的绝对路径abpath来判断是否return，而非依据name，经过测试，该BUG已经修复。

**谨慎起见，原searchNode(root,name)，我仍然保留，其他调用searchNode(root,name)方法的文件我也未修改**
