### PR TITLE
修复了由Base64产生的+字符没有进行url编码的问题

### DIFF
--- a/src/com/ms509/util/Shell.java
+++ b/src/com/ms509/util/Shell.java
@@ -188,7 +188,12 @@ public class Shell {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
-		tmp = (new BASE64Encoder().encode(z12)).toString() + "&"+Safe.PARAM2+"=" + (new BASE64Encoder().encode(z22)).toString();
+				
+		//这里要进行一些url编码，否则执行echo ';' > t.php时就会产生+和换行，导致目标端解析base64失败
+		String change = (new BASE64Encoder().encode(z22)).toString();
+		change = change.replace("+","%2b").replace("\n","");
+		 
+		tmp = (new BASE64Encoder().encode(z12)).toString() + "&"+Safe.PARAM2+"=" + change;
 		params = Common.makeParams(Safe.PHP_MAKE, Safe.PHP_SHELL, tmp);
 		String[] index_datas = Common.send(url, params, code).split("\t");
 		String result = null;


### PR DESCRIPTION
用这个软件时，用模拟终端执行下面的命令时
echo "l" > t.php
会报错：
java.lang.StringIndexOutOfBoundsException: String index out of range: -2
        at java.lang.String.substring(String.java:1967)
        at com.ms509.util.Shell.execute_php(Shell.java:196)
        at com.ms509.util.Shell.execute(Shell.java:49)
        at com.ms509.ui.panel.ShellPanel.execute(ShellPanel.java:343)
        at com.ms509.ui.panel.ShellPanel$textareaKey$1.run(ShellPanel.java:282)
        at java.lang.Thread.run(Thread.java:748)

echo ';' > t.php
命令也有这种情况
在调试过程中发现了该bug
修改了一下